### PR TITLE
Make handling errors/flash messages easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To show them to your users, add this to your `login.blade.php`:
 ```blade
 @if (session('confirmation'))
     <div class="alert alert-info" role="alert">
-        {{ session('confirmation') }}
+        {!! session('confirmation') !!}
     </div>
 @endif
 ```

--- a/src/Traits/AuthenticatesUsers.php
+++ b/src/Traits/AuthenticatesUsers.php
@@ -17,7 +17,6 @@ trait AuthenticatesUsers
      *
      * @param  \Illuminate\Http\Request $request
      * @return bool
-     * @throws ValidationException
      */
     protected function attemptLogin(Request $request)
     {
@@ -29,16 +28,14 @@ trait AuthenticatesUsers
             }
 
             session([
-                'confirmation_user_id' => $user->getKey()
+                'confirmation_user_id' => $user->getKey(),
             ]);
 
-            throw ValidationException::withMessages([
-                'confirmation' => [
-                    __('confirmation::confirmation.not_confirmed', [
-                        'resend_link' => route('auth.resend_confirmation')
-                    ])
-                ]
-            ]);
+            $request->session()->flash(
+                'confirmation', __('confirmation::confirmation.not_confirmed', [
+                    'resend_link' => route('auth.resend_confirmation')
+                ])
+            );
         }
         return false;
     }

--- a/src/Traits/RegistersUsers.php
+++ b/src/Traits/RegistersUsers.php
@@ -61,7 +61,7 @@ trait RegistersUsers
         $this->sendConfirmationToUser($user);
 
         return $this->registered($request, $user)
-            ?: redirect($this->redirectPath())->with('confirmation', __('confirmation::confirmation.confirmation_info'));
+            ?: redirect(route('login'))->with('confirmation', __('confirmation::confirmation.confirmation_info'));
     }
 
     /**

--- a/tests/ConfirmationTest.php
+++ b/tests/ConfirmationTest.php
@@ -45,7 +45,9 @@ class ConfirmationTest extends TestCase
         ]);
 
         $response->assertSessionHas('confirmation_user_id', $user->getKey());
-        $response->assertSessionHasErrors('confirmation');
+        $response->assertSessionHas('confirmation', __('confirmation::confirmation.not_confirmed', [
+            'resend_link' => route('auth.resend_confirmation')
+        ]));
         $this->assertFalse(auth()->check());
     }
 


### PR DESCRIPTION
As per #8, throwing the validation exception in the case of an attempted login, by an unregistered user, adds to the errors stack, rather than the 'confirmation' key in the session. Resulting in this having to be handled differently in the template, which isn't clear in the readme. 

Instead of throwing an exception, can we just flash the message and fail the login as normal? A user not having confirmed yet, feel's to me more like a notice than a validation failure, and this behaviour would make the integration of the package as simple as possible, rather than having to handle flash messages and errors in the template.

Maybe this should be a separate commit, but on registration, we should just return a redirect straight to the login page, rather than the 'redirect path', as the user will be unconfirmed at this point and can't go anywhere other than login anyway.

I'm fairly new to Laravel and contributing to open source, so I'm more than happy to take any advice and work on an alternative solution or amend as per suggestion! 😄   