### PR TITLE
Prevent password reset bypassing email confirmation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ To show them to your users, add this to your `login.blade.php`:
         {!! session('confirmation') !!}
     </div>
 @endif
+```
+and this to both your `login.blade.php` and `email.blade.php`
+```blade
 @if ($errors->has('confirmation') > 0 )
     <div class="alert alert-danger" role="alert">
         {!! $errors->first('confirmation') !!}

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ And run the migrations:
 php artisan migrate
 ```
 
-### Configuring the login and register controllers
-In order to make use of the email verification, replace the `AuthenticatesUsers` and `RegistersUsers` traits that
+### Configuring the login, register and forgot password controllers
+In order to make use of the email verification, replace the `AuthenticatesUsers`, `RegistersUsers` and the `SendsPasswordResetEmails` traits that
 come with Laravel, with the ones provided by this package.
 
-These traits can be found in these two files:
+These traits can be found in these three files:
 
 - `App\Http\Controllers\Auth\LoginController`
 - `App\Http\Controllers\Auth\RegisterController`
+- `App\Http\Controllers\Auth\SendsPasswordResetEmails`
 
 ### Add the confirmation and resend routes
 

--- a/resources/lang/en/confirmation.php
+++ b/resources/lang/en/confirmation.php
@@ -7,6 +7,7 @@ return [
     'confirmation_button' => 'Verify now',
 
     'not_confirmed' => 'The given email address has not been confirmed. <a href=":resend_link">Resend confirmation link.</a>',
+    'not_confirmed_reset_password' => 'The given email address has not been confirmed. To reset the password you must first confirm the email address.<a href=":resend_link">Resend confirmation link.</a>',
     'confirmation_successful' => 'You successfully confirmed your email address. Please log in.',
     'confirmation_info' => 'Please confirm your email address.',
     'confirmation_resent' => 'We sent you another confirmation email. You should receive it shortly.',

--- a/src/Traits/SendsPasswordResetEmails.php
+++ b/src/Traits/SendsPasswordResetEmails.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BeyondCode\EmailConfirmation\Traits;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Trait SendsPasswordResetEmails
+ * @package BeyondCode\EmailConfirmation\Traits
+ */
+trait SendsPasswordResetEmails
+{
+    use \Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+
+    /**
+     * Send a reset link to the given user.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     * @throws ValidationException
+     */
+    public function sendResetLinkEmail(Request $request)
+    {
+        $this->validateEmail($request);
+
+        $user = $this->broker()->getUser($request->only('email'));
+
+        // If the user hasn't confirmed their email address,
+        // we will throw a validation exception for this error.
+        // A user can not request a password reset link if they are not confirmed.
+        if (is_null($user->confirmed_at)) {
+            throw ValidationException::withMessages([
+                'confirmation' => [
+                    __('confirmation::confirmation.not_confirmed_reset_password', [
+                        'resend_link' => route('auth.resend_confirmation')
+                    ])
+                ]
+            ]);
+        }
+
+        // We will send the password reset link to this user. Once we have attempted
+        // to send the link, we will examine the response then see the message we
+        // need to show to the user. Finally, we'll send out a proper response.
+        $response = $this->broker()->sendResetLink(
+            $request->only('email')
+        );
+
+        return $response == Password::RESET_LINK_SENT
+            ? $this->sendResetLinkResponse($response)
+            : $this->sendResetLinkFailedResponse($request, $response);
+    }
+}

--- a/tests/ConfirmationTest.php
+++ b/tests/ConfirmationTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\EmailConfirmation\Tests;
 
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use BeyondCode\EmailConfirmation\Tests\Models\User;
 use BeyondCode\EmailConfirmation\Notifications\ConfirmEmail;
@@ -117,5 +118,25 @@ class ConfirmationTest extends TestCase
         $response = $this->get('/register/confirm/foo');
 
         $response->assertStatus(404);
+    }
+
+    /** @test */
+    public function it_does_not_allow_reset_password_request_for_unconfirmed_users()
+    {
+        Notification::fake();
+
+        $user = User::create([
+            'email' => 'marcel@beyondco.de',
+            'password' => bcrypt('test123'),
+            'confirmed_at' => null,
+        ]);
+
+        $response = $this->post('/password/email', [
+            'email' => 'marcel@beyondco.de',
+        ]);
+
+        $response->assertSessionHasErrors('confirmation');
+
+        Notification::assertNotSentTo($user, ResetPassword::class);
     }
 }

--- a/tests/Controllers/ForgotPasswordController.php
+++ b/tests/Controllers/ForgotPasswordController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BeyondCode\EmailConfirmation\Tests\Controllers;
+
+use BeyondCode\EmailConfirmation\Traits\SendsPasswordResetEmails;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller;
+
+class ForgotPasswordController extends Controller
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Controller
+    |--------------------------------------------------------------------------
+    |
+    | This controller is responsible for handling password reset emails and
+    | includes a trait which assists in sending these notifications from
+    | your application to your users. Feel free to explore this trait.
+    |
+    */
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests, SendsPasswordResetEmails;
+}

--- a/tests/Controllers/LoginController.php
+++ b/tests/Controllers/LoginController.php
@@ -11,14 +11,14 @@ use BeyondCode\EmailConfirmation\Traits\AuthenticatesUsers;
 class LoginController extends Controller
 {
     /*
-    |--------------------------------------------------------------------------
-    | Register Controller
-    |--------------------------------------------------------------------------
-    |
-    | This controller handles the registration of new users as well as their
-    | validation and creation. By default this controller uses a trait to
-    | provide this functionality without requiring any additional code.
-    |
-    */
+   |--------------------------------------------------------------------------
+   | Login Controller
+   |--------------------------------------------------------------------------
+   |
+   | This controller handles authenticating users for the application and
+   | redirecting them to your home screen. The controller uses a trait
+   | to conveniently provide its functionality to your applications.
+   |
+   */
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests, AuthenticatesUsers;
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\EmailConfirmation\Tests;
 
+use BeyondCode\EmailConfirmation\Tests\Controllers\ForgotPasswordController;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
@@ -82,5 +83,6 @@ class TestCase extends Orchestra
         Route::name('login')->post('/login', LoginController::class.'@login');
         Route::name('auth.resend_confirmation')->get('/resend', RegisterController::class.'@resendConfirmation');
         Route::name('auth.confirm')->get('/register/confirm/{confirmation_code}', RegisterController::class.'@confirm');
+        Route::name('password.email')->post('/password/email', ForgotPasswordController::class.'@sendResetLinkEmail');
     }
 }


### PR DESCRIPTION
Proposed fix for #6. Prevents users from requesting a new password if not confirmed and throw error message with a 'Resend activation link'. 