### PR TITLE
Ensure session has confirmation_user_id

### DIFF
--- a/src/Traits/SendsPasswordResetEmails.php
+++ b/src/Traits/SendsPasswordResetEmails.php
@@ -31,6 +31,9 @@ trait SendsPasswordResetEmails
         // we will throw a validation exception for this error.
         // A user can not request a password reset link if they are not confirmed.
         if (is_null($user->confirmed_at)) {
+
+            session(['confirmation_user_id' => $user->getKey()]);
+
             throw ValidationException::withMessages([
                 'confirmation' => [
                     __('confirmation::confirmation.not_confirmed_reset_password', [

--- a/tests/ConfirmationTest.php
+++ b/tests/ConfirmationTest.php
@@ -135,6 +135,8 @@ class ConfirmationTest extends TestCase
             'email' => 'marcel@beyondco.de',
         ]);
 
+        $response->assertSessionHas('confirmation_user_id', $user->getKey());
+
         $response->assertSessionHasErrors('confirmation');
 
         Notification::assertNotSentTo($user, ResetPassword::class);


### PR DESCRIPTION
Ensure session has confirmation_user_id for resending confirmation