### PR TITLE
On registration, redirect straight to login page to ensure flash mess…

### DIFF
--- a/src/Traits/RegistersUsers.php
+++ b/src/Traits/RegistersUsers.php
@@ -61,7 +61,7 @@ trait RegistersUsers
         $this->sendConfirmationToUser($user);
 
         return $this->registered($request, $user)
-            ?: redirect($this->redirectPath())->with('confirmation', __('confirmation::confirmation.confirmation_info'));
+            ?: redirect(route('login'))->with('confirmation', __('confirmation::confirmation.confirmation_info'));
     }
 
     /**


### PR DESCRIPTION
…age is shown.

Currently on registration, because we don't redirect straight to the login page, we don't see the flash message.