### PR TITLE
Fix the request argument does not send

### DIFF
--- a/src/Traits/SendsPasswordResetEmails.php
+++ b/src/Traits/SendsPasswordResetEmails.php
@@ -51,7 +51,7 @@ trait SendsPasswordResetEmails
         );
 
         return $response == Password::RESET_LINK_SENT
-            ? $this->sendResetLinkResponse($response)
+            ? $this->sendResetLinkResponse($request, $response)
             : $this->sendResetLinkFailedResponse($request, $response);
     }
 }


### PR DESCRIPTION
Argument 1 passed to App\Http\Controllers\Auth\ForgotPasswordController::sendResetLinkResponse() must be an instance of Illuminate\Http\Request, string given, called

Fix the request argument does not send  to sendResetLinkResponse