### PR TITLE
Fix bad spacing in a en locale string in confirmation.php

### DIFF
--- a/resources/lang/en/confirmation.php
+++ b/resources/lang/en/confirmation.php
@@ -7,7 +7,7 @@ return [
     'confirmation_button' => 'Verify now',
 
     'not_confirmed' => 'The given email address has not been confirmed. <a href=":resend_link">Resend confirmation link.</a>',
-    'not_confirmed_reset_password' => 'The given email address has not been confirmed. To reset the password you must first confirm the email address.<a href=":resend_link">Resend confirmation link.</a>',
+    'not_confirmed_reset_password' => 'The given email address has not been confirmed. To reset the password you must first confirm the email address. <a href=":resend_link">Resend confirmation link.</a>',
     'confirmation_successful' => 'You successfully confirmed your email address. Please log in.',
     'confirmation_info' => 'Please confirm your email address.',
     'confirmation_resent' => 'We sent you another confirmation email. You should receive it shortly.',


### PR DESCRIPTION
There should be a space after '.'